### PR TITLE
.NET 3.5 support and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+obj/
+[Bb]in
+[Dd]ebug*/
+[Rr]elease*/
+*.[Oobj]
+*.user
+*.suo
+*.bak

--- a/Sigil NET35/Sigil NET35.csproj
+++ b/Sigil NET35/Sigil NET35.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sigil</RootNamespace>
+    <AssemblyName>Sigil</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Sigil.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Sigil.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Sigil\**\*.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Sigil.sln
+++ b/Sigil.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestRunner", "TestRunner\TestRunner.csproj", "{1FE8362E-A099-4739-9B1F-12ADCF10BA02}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sigil NET35", "Sigil NET35\Sigil NET35.csproj", "{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{1FE8362E-A099-4739-9B1F-12ADCF10BA02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FE8362E-A099-4739-9B1F-12ADCF10BA02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FE8362E-A099-4739-9B1F-12ADCF10BA02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{546A8668-56BF-4F71-A9F9-489B2BA5B5E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sigil/CatchBlock.cs
+++ b/Sigil/CatchBlock.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Arithmetic.cs
+++ b/Sigil/Emit.Arithmetic.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 using Sigil.Impl;
 using System.Reflection.Emit;
 

--- a/Sigil/Emit.Bitwise.cs
+++ b/Sigil/Emit.Bitwise.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 using Sigil.Impl;
 using System.Reflection.Emit;
 

--- a/Sigil/Emit.Box.cs
+++ b/Sigil/Emit.Box.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.Branch.cs
+++ b/Sigil/Emit.Branch.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil
@@ -27,7 +22,7 @@ namespace Sigil
             }
 
             UnusedLabels.Remove(label);
-
+            
             BufferedILGenerator.UpdateOpCodeDelegate update;
 
             UpdateState(OpCodes.Br, label, out update);

--- a/Sigil/Emit.Break.cs
+++ b/Sigil/Emit.Break.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection.Emit;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Call.cs
+++ b/Sigil/Emit.Call.cs
@@ -1,11 +1,8 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {
@@ -44,7 +41,7 @@ namespace Sigil
             var expectedParams = method.GetParameters().Select(s => TypeOnStack.Get(s.ParameterType)).ToList();
 
             // Instance methods expect this to preceed parameters
-            if (method.CallingConvention.HasFlag(CallingConventions.HasThis))
+            if (HasFlag(method.CallingConvention, CallingConventions.HasThis))
             {
                 expectedParams.Insert(0, TypeOnStack.Get(method.DeclaringType));
             }
@@ -68,7 +65,7 @@ namespace Sigil
                 {
                     // OK, apparently for the `this` pointer, you can get away with using an explicit reference (type &) rather than
                     //   an "object reference" (type O)
-                    if (i == 0 && actuallyIs.IsReference && method.CallingConvention.HasFlag(CallingConventions.HasThis))
+                    if (i == 0 && actuallyIs.IsReference && HasFlag(method.CallingConvention, CallingConventions.HasThis))
                     {
                         var actuallyIsDeref = TypeOnStack.Get(actuallyIs.Type);
                         if (shouldBe.IsAssignableFrom(actuallyIsDeref))
@@ -84,8 +81,8 @@ namespace Sigil
             var resultType = method.ReturnType == typeof(void) ? null : TypeOnStack.Get(method.ReturnType);
 
             var firstParamIsThis =
-                method.CallingConvention.HasFlag(CallingConventions.HasThis) ||
-                method.CallingConvention.HasFlag(CallingConventions.ExplicitThis);
+                HasFlag(method.CallingConvention, CallingConventions.HasThis) ||
+                HasFlag(method.CallingConvention, CallingConventions.ExplicitThis);
             
             UpdateState(OpCodes.Call, method, resultType, pop: expectedParams.Count, firstParamIsThis: firstParamIsThis);
 

--- a/Sigil/Emit.CallIndirect.cs
+++ b/Sigil/Emit.CallIndirect.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {
@@ -18,7 +14,9 @@ namespace Sigil
         /// 
         /// This helper assumes a void return and no parameters.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(void), Type.EmptyTypes);
@@ -32,7 +30,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and no parameters.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType));
@@ -44,7 +44,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1));
@@ -56,7 +58,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2));
@@ -68,7 +72,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3));
@@ -80,7 +86,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4));
@@ -92,7 +100,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5));
@@ -104,7 +114,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6));
@@ -116,7 +128,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7));
@@ -128,7 +142,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8));
@@ -140,7 +156,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9));
@@ -152,7 +170,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10));
@@ -164,7 +184,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11));
@@ -176,7 +198,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12));
@@ -188,7 +212,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13));
@@ -200,7 +226,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14));
@@ -212,7 +240,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14, ParameterType15>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14), typeof(ParameterType15));
@@ -224,7 +254,9 @@ namespace Sigil
         /// 
         /// This helper assumes ReturnType as a return and parameters of the types given in ParameterType*.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> CallIndirect<ReturnType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14, ParameterType15, ParameterType16>(CallingConventions callConventions)
         {
             return CallIndirect(callConventions, typeof(ReturnType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14), typeof(ParameterType15), typeof(ParameterType16));
@@ -263,7 +295,7 @@ namespace Sigil
 
             var takeExtra = 1;
 
-            if (callConventions.HasFlag(CallingConventions.HasThis))
+            if (HasFlag(callConventions, CallingConventions.HasThis))
             {
                 takeExtra++;
             }
@@ -283,7 +315,7 @@ namespace Sigil
             reversed.RemoveAt(reversed.Count - 1);
 
             TypeOnStack thisType = null;
-            if (callConventions.HasFlag(CallingConventions.HasThis))
+            if (HasFlag(callConventions, CallingConventions.HasThis))
             {
                 thisType = reversed[0];
                 reversed.RemoveAt(0);

--- a/Sigil/Emit.CallVirtual.cs
+++ b/Sigil/Emit.CallVirtual.cs
@@ -1,11 +1,8 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.CastClass.cs
+++ b/Sigil/Emit.CastClass.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.CheckFinite.cs
+++ b/Sigil/Emit.CheckFinite.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Compare.cs
+++ b/Sigil/Emit.Compare.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Convert.cs
+++ b/Sigil/Emit.Convert.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.CopyBlock.cs
+++ b/Sigil/Emit.CopyBlock.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.CopyObject.cs
+++ b/Sigil/Emit.CopyObject.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.Duplicate.cs
+++ b/Sigil/Emit.Duplicate.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection.Emit;
 
 namespace Sigil
 {

--- a/Sigil/Emit.InitializeBlock.cs
+++ b/Sigil/Emit.InitializeBlock.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.InitializeObject.cs
+++ b/Sigil/Emit.InitializeObject.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.IsInstance.cs
+++ b/Sigil/Emit.IsInstance.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.Jump.cs
+++ b/Sigil/Emit.Jump.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Labels.cs
+++ b/Sigil/Emit.Labels.cs
@@ -1,10 +1,7 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Leave.cs
+++ b/Sigil/Emit.Leave.cs
@@ -1,10 +1,7 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadArgument.cs
+++ b/Sigil/Emit.LoadArgument.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadArgumentAddress.cs
+++ b/Sigil/Emit.LoadArgumentAddress.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadConstant.cs
+++ b/Sigil/Emit.LoadConstant.cs
@@ -1,11 +1,7 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadElement.cs
+++ b/Sigil/Emit.LoadElement.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 using Sigil.Impl;
 using System.Reflection.Emit;
 

--- a/Sigil/Emit.LoadElementAddress.cs
+++ b/Sigil/Emit.LoadElementAddress.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadField.cs
+++ b/Sigil/Emit.LoadField.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 using System.Reflection.Emit;
 
 namespace Sigil
@@ -17,7 +12,7 @@ namespace Sigil
         /// 
         /// Instance fields expect a reference on the stack, which is popped.
         /// </summary>
-        public Emit<DelegateType> LoadField(FieldInfo field, bool isVolatile = false, int? unaligned = null)
+        public Emit<DelegateType> LoadField(FieldInfo field, int? unaligned = null)
         {
             if (field == null)
             {
@@ -33,6 +28,8 @@ namespace Sigil
             {
                 throw new ArgumentException("unaligned cannot be used with static fields");
             }
+
+            var isVolatile = Array.IndexOf(field.GetRequiredCustomModifiers(), typeof(System.Runtime.CompilerServices.IsVolatile)) >= 0;
 
             if (!field.IsStatic)
             {

--- a/Sigil/Emit.LoadFieldAddress.cs
+++ b/Sigil/Emit.LoadFieldAddress.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadFunctionPointer.cs
+++ b/Sigil/Emit.LoadFunctionPointer.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {
@@ -29,7 +25,7 @@ namespace Sigil
             var paramList = parameters.Select(p => p.ParameterType).ToList();
 
             var thisType =
-                method.CallingConvention.HasFlag(CallingConventions.HasThis) ?
+                HasFlag(method.CallingConvention, CallingConventions.HasThis) ?
                     method.DeclaringType :
                     null;
 

--- a/Sigil/Emit.LoadIndirect.cs
+++ b/Sigil/Emit.LoadIndirect.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadLength.cs
+++ b/Sigil/Emit.LoadLength.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadLocal.cs
+++ b/Sigil/Emit.LoadLocal.cs
@@ -1,10 +1,6 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadLocalAddress.cs
+++ b/Sigil/Emit.LoadLocalAddress.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadObject.cs
+++ b/Sigil/Emit.LoadObject.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.LoadVirtualFunctionPointer.cs
+++ b/Sigil/Emit.LoadVirtualFunctionPointer.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {
@@ -30,7 +26,7 @@ namespace Sigil
             }
 
             var thisType =
-                method.CallingConvention.HasFlag(CallingConventions.HasThis) ?
+                HasFlag(method.CallingConvention, CallingConventions.HasThis) ?
                     method.DeclaringType :
                     null;
 

--- a/Sigil/Emit.LocalAllocate.cs
+++ b/Sigil/Emit.LocalAllocate.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Locals.cs
+++ b/Sigil/Emit.Locals.cs
@@ -1,9 +1,5 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.NewArray.cs
+++ b/Sigil/Emit.NewArray.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.NewObject.cs
+++ b/Sigil/Emit.NewObject.cs
@@ -1,11 +1,8 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {
@@ -16,7 +13,9 @@ namespace Sigil
         /// <summary>
         /// Invokes the parameterless constructor of the given type, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType>()
         {
             return NewObject(typeof(ReferenceType));
@@ -25,7 +24,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1));
@@ -34,7 +35,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2));
@@ -43,7 +46,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3));
@@ -52,7 +57,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4));
@@ -61,7 +68,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5));
@@ -70,7 +79,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6));
@@ -79,7 +90,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7));
@@ -88,7 +101,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8));
@@ -97,7 +112,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9));
@@ -106,7 +123,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10));
@@ -115,7 +134,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11));
@@ -124,7 +145,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12));
@@ -133,7 +156,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13));
@@ -142,7 +167,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14));
@@ -151,7 +178,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14, ParameterType15>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14), typeof(ParameterType15));
@@ -160,7 +189,9 @@ namespace Sigil
         /// <summary>
         /// Pops # of parameter arguments from the stack, invokes the the constructor of the given reference type that matches the given parameter types, and pushes a reference to the new object onto the stack.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public Emit<DelegateType> NewObject<ReferenceType, ParameterType1, ParameterType2, ParameterType3, ParameterType4, ParameterType5, ParameterType6, ParameterType7, ParameterType8, ParameterType9, ParameterType10, ParameterType11, ParameterType12, ParameterType13, ParameterType14, ParameterType15, ParameterType16>()
         {
             return NewObject(typeof(ReferenceType), typeof(ParameterType1), typeof(ParameterType2), typeof(ParameterType3), typeof(ParameterType4), typeof(ParameterType5), typeof(ParameterType6), typeof(ParameterType7), typeof(ParameterType8), typeof(ParameterType9), typeof(ParameterType10), typeof(ParameterType11), typeof(ParameterType12), typeof(ParameterType13), typeof(ParameterType14), typeof(ParameterType15), typeof(ParameterType16));
@@ -194,7 +225,7 @@ namespace Sigil
 
             if (cons == null)
             {
-                throw new InvalidOperationException("Type " + type + " must have a constructor that matches parameters [" + string.Join(", ", parameterTypes.AsEnumerable()) + "]");
+                throw new InvalidOperationException("Type " + type + " must have a constructor that matches parameters [" + BufferedILGenerator.Join(", ", parameterTypes.AsEnumerable()) + "]");
             }
 
             return NewObject(cons);

--- a/Sigil/Emit.Nop.cs
+++ b/Sigil/Emit.Nop.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection.Emit;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Pop.cs
+++ b/Sigil/Emit.Pop.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection.Emit;
 
 namespace Sigil
 {

--- a/Sigil/Emit.ReThrow.cs
+++ b/Sigil/Emit.ReThrow.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Return.cs
+++ b/Sigil/Emit.Return.cs
@@ -1,11 +1,6 @@
-﻿using System;
+﻿using Sigil.Impl;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.SizeOf.cs
+++ b/Sigil/Emit.SizeOf.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.StoreArgument.cs
+++ b/Sigil/Emit.StoreArgument.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.StoreElement.cs
+++ b/Sigil/Emit.StoreElement.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.StoreField.cs
+++ b/Sigil/Emit.StoreField.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.StoreIndirect.cs
+++ b/Sigil/Emit.StoreIndirect.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
 
 namespace Sigil

--- a/Sigil/Emit.StoreLocal.cs
+++ b/Sigil/Emit.StoreLocal.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.StoreObject.cs
+++ b/Sigil/Emit.StoreObject.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Switch.cs
+++ b/Sigil/Emit.Switch.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Throw.cs
+++ b/Sigil/Emit.Throw.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Sigil.Impl;
+using System;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {

--- a/Sigil/Emit.TryCatchFinally.cs
+++ b/Sigil/Emit.TryCatchFinally.cs
@@ -1,11 +1,7 @@
-﻿using System;
+﻿using Sigil.Impl;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
-using System.Reflection.Emit;
 
 namespace Sigil
 {

--- a/Sigil/Emit.Unbox.cs
+++ b/Sigil/Emit.Unbox.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sigil.Impl;
+using System;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
-
-using Sigil.Impl;
 
 namespace Sigil
 {
@@ -84,9 +80,9 @@ namespace Sigil
                 throw new ArgumentNullException("valueType");
             }
 
-            if (!valueType.IsValueType || valueType.IsByRef || valueType.IsPointer)
+            if (valueType.IsByRef || valueType.IsPointer)
             {
-                throw new ArgumentException("UnboxAny expects a ValueType, found " + valueType);
+                throw new ArgumentException("UnboxAny cannot operate on pointers, found " + valueType);
             }
 
             if (valueType == typeof(void))

--- a/Sigil/Emit.Validate.cs
+++ b/Sigil/Emit.Validate.cs
@@ -4,14 +4,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {
     public partial class Emit<DelegateType>
     {
-        private void FailStackUnderflow(int expected, [CallerMemberName]string method = null)
+        private void FailStackUnderflow(int expected
+#if NET35
+            , string method = "caller"
+#else
+            , [CallerMemberName]string method = null
+#endif
+)
         {
             if (expected == 1)
             {
@@ -26,7 +30,13 @@ namespace Sigil
             throw new ArgumentException(obj + " is not owned by this Emit, and thus cannot be used");
         }
 
-        private void FailUnverifiable([CallerMemberName]string method = null)
+        private void FailUnverifiable(
+#if NET35
+            string method = "caller"
+#else
+            [CallerMemberName]string method = null
+#endif
+            )
         {
             throw new InvalidOperationException(method + " isn't verifiable");
         }
@@ -37,7 +47,7 @@ namespace Sigil
             {
                 throw 
                     new SigilVerificationException(
-                        "Locals [" + string.Join(", ", UnusedLocals.Select(u => u.Name)) + "] were declared but never used",
+                        "Locals [" + BufferedILGenerator.Join(", ", UnusedLocals.Select(u => u.Name)) + "] were declared but never used",
                         IL.Instructions(Locals),
                         Stack
                     );
@@ -47,7 +57,7 @@ namespace Sigil
             {
                 throw 
                     new SigilVerificationException(
-                        "Labels [" + string.Join(", ", UnusedLabels.Select(l => l.Name)) + "] were declared but never used",
+                        "Labels [" + BufferedILGenerator.Join(", ", UnusedLabels.Select(l => l.Name)) + "] were declared but never used",
                         IL.Instructions(Locals),
                         Stack
                     );

--- a/Sigil/EmitShorthand.cs
+++ b/Sigil/EmitShorthand.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {
@@ -676,9 +672,9 @@ namespace Sigil
         }
 
         /// <summary cref="M:Sigil.Emit`1.LoadField(System.Reflection.FieldInfo, System.Boolean, System.Nullable&lt;int&gt;)" />
-        public EmitShorthand<DelegateType> Ldfld(FieldInfo field, bool isVolatile = false, int? unaligned = null)
+        public EmitShorthand<DelegateType> Ldfld(FieldInfo field, int? unaligned = null)
         {
-            InnerEmit.LoadField(field, isVolatile, unaligned);
+            InnerEmit.LoadField(field, unaligned);
 
             return this;
         }

--- a/Sigil/ExceptionBlock.cs
+++ b/Sigil/ExceptionBlock.cs
@@ -1,9 +1,4 @@
 ﻿using Sigil.Impl;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/FinallyBlock.cs
+++ b/Sigil/FinallyBlock.cs
@@ -1,9 +1,4 @@
 ﻿using Sigil.Impl;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Impl/AutoNamer.cs
+++ b/Sigil/Impl/AutoNamer.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {

--- a/Sigil/Impl/BufferedILGenerator.cs
+++ b/Sigil/Impl/BufferedILGenerator.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {
@@ -106,7 +105,7 @@ namespace Sigil.Impl
                 }
 
                 ret.Add(line);
-                instrs.Clear();
+                instrs.Length = 0;
             }
 
             return ret.ToArray();
@@ -488,11 +487,27 @@ namespace Sigil.Impl
                         il.Emit(localOp, ls);
                     }
 
-                    log.AppendLine(localOp + " " + string.Join(", ", labels.AsEnumerable()));
+                    log.AppendLine(localOp + " " + Join(", ", labels.AsEnumerable()));
                 }
             );
         }
-
+        internal static string Join<T>(string delimiter, IEnumerable<T> parts) where T: class
+        {
+            using (var iter = parts.GetEnumerator())
+            {
+                if (!iter.MoveNext()) return "";
+                var sb = new StringBuilder();
+                var next = iter.Current;
+                if (next != null) sb.Append(next);
+                while (iter.MoveNext())
+                {
+                    sb.Append(delimiter);
+                    next = iter.Current;
+                    if (next != null) sb.Append(next);
+                }
+                return sb.ToString();
+            }
+        }
         public void Emit(OpCode op, Sigil.Local local)
         {
             InstructionSizes.Add(() => InstructionSize.Get(op));
@@ -523,7 +538,7 @@ namespace Sigil.Impl
                         il.EmitCalli(op, callConventions, returnType, parameterTypes, null);
                     }
 
-                    log.AppendLine(op + " " + callConventions + " " + returnType + " " + string.Join(" ", (IEnumerable<Type>)parameterTypes));
+                    log.AppendLine(op + " " + callConventions + " " + returnType + " " + Join(" ", (IEnumerable<Type>)parameterTypes));
                 }
             );
         }

--- a/Sigil/Impl/ExtensionMethods.cs
+++ b/Sigil/Impl/ExtensionMethods.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {

--- a/Sigil/Impl/IOwned.cs
+++ b/Sigil/Impl/IOwned.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Sigil.Impl
 {
     internal interface IOwned

--- a/Sigil/Impl/InstructionSize.cs
+++ b/Sigil/Impl/InstructionSize.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {

--- a/Sigil/Impl/StackState.cs
+++ b/Sigil/Impl/StackState.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {

--- a/Sigil/Impl/TypeOnStack.cs
+++ b/Sigil/Impl/TypeOnStack.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil.Impl
 {

--- a/Sigil/Label.cs
+++ b/Sigil/Label.cs
@@ -1,10 +1,4 @@
 ﻿using Sigil.Impl;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Local.cs
+++ b/Sigil/Local.cs
@@ -1,10 +1,5 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {

--- a/Sigil/Properties/AssemblyInfo.cs
+++ b/Sigil/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Sigil")]

--- a/Sigil/Sigil.csproj
+++ b/Sigil/Sigil.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Emit.TryCatchFinally.cs">
       <DependentUpon>Emit.cs</DependentUpon>
     </Compile>
+    <Compile Include="Tuple.cs" />
     <Compile Include="Emit.Unbox.cs">
       <DependentUpon>Emit.cs</DependentUpon>
     </Compile>

--- a/Sigil/SigilException.cs
+++ b/Sigil/SigilException.cs
@@ -1,10 +1,8 @@
 ﻿using Sigil.Impl;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Sigil
 {
@@ -154,7 +152,9 @@ namespace Sigil
         /// <summary>
         /// Implementation for ISerializable.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -168,7 +168,9 @@ namespace Sigil
         /// <summary>
         /// Returns the message and stacks on this exception, in string form.
         /// </summary>
+#if !NET35
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
         public override string ToString()
         {
             return

--- a/Sigil/Tuple.cs
+++ b/Sigil/Tuple.cs
@@ -1,0 +1,124 @@
+﻿
+using System;
+using System.Collections.Generic;
+namespace Sigil
+{
+#if NET35
+        static class Tuple {
+            public static Tuple<T1,T2> Create<T1,T2>(T1 item1, T2 item2) { return new Tuple<T1,T2>(item1, item2); }
+            public static Tuple<T1,T2,T3> Create<T1,T2,T3>(T1 item1, T2 item2, T3 item3) { return new Tuple<T1,T2,T3>(item1, item2, item3); }
+            public static Tuple<T1,T2,T3,T4> Create<T1,T2,T3,T4>(T1 item1, T2 item2, T3 item3, T4 item4) { return new Tuple<T1,T2,T3,T4>(item1, item2, item3, item4); }
+        }
+        class Tuple<T1,T2> : IEquatable<Tuple<T1,T2>> {
+            private readonly T1 item1;
+            private readonly T2 item2;
+            public T1 Item1 { get { return item1; } }
+            public T2 Item2 { get { return item2; } }
+            public Tuple(T1 item1, T2 item2) {
+                this.item1 = item1;
+                this.item2 = item2;
+            }
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Tuple<T1,T2>);
+            }
+            public bool Equals(Tuple<T1,T2> obj)
+            {
+                if (obj == null) return false;
+                if (obj == this) return true;
+                return EqualityComparer<T1>.Default.Equals(obj.item1, this.item1)
+                    && EqualityComparer<T2>.Default.Equals(obj.item2, this.item2);
+            }
+            public override int GetHashCode()
+            {
+                var hash = 13;
+                hash = (hash * -17) + EqualityComparer<T1>.Default.GetHashCode(this.item1);
+                hash = (hash * -17) + EqualityComparer<T2>.Default.GetHashCode(this.item2);
+                return hash;
+            }
+            public override string ToString()
+            {
+                return "(" + this.item1 + "," + this.item2 + ")";
+            }
+        }
+        class Tuple<T1,T2, T3>  : IEquatable<Tuple<T1,T2,T3>> {
+            private readonly T1 item1;
+            private readonly T2 item2;
+            private readonly T3 item3;
+            public T1 Item1 { get { return item1; } }
+            public T2 Item2 { get { return item2; } }
+            public T3 Item3 { get { return item3; } }
+            public Tuple(T1 item1, T2 item2, T3 item3) {
+                this.item1 = item1;
+                this.item2 = item2;
+                this.item3 = item3;
+            }
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Tuple<T1, T2, T3>);
+            }
+            public bool Equals(Tuple<T1, T2, T3> obj)
+            {
+                if (obj == null) return false;
+                if (obj == this) return true;
+                return EqualityComparer<T1>.Default.Equals(obj.item1, this.item1)
+                    && EqualityComparer<T2>.Default.Equals(obj.item2, this.item2)
+                    && EqualityComparer<T3>.Default.Equals(obj.item3, this.item3);
+            }
+            public override int GetHashCode()
+            {
+                var hash = 13;
+                hash = (hash * -17) + EqualityComparer<T1>.Default.GetHashCode(this.item1);
+                hash = (hash * -17) + EqualityComparer<T2>.Default.GetHashCode(this.item2);
+                hash = (hash * -17) + EqualityComparer<T3>.Default.GetHashCode(this.item3);
+                return hash;
+            }
+            public override string ToString()
+            {
+                return "(" + this.item1 + "," + this.item2 + "," + this.item3 + ")";
+            }
+        }
+        class Tuple<T1,T2, T3, T4>  : IEquatable<Tuple<T1,T2,T3,T4>>{
+            private readonly T1 item1;
+            private readonly T2 item2;
+            private readonly T3 item3;
+            private readonly T4 item4;
+            public T1 Item1 { get { return item1; } }
+            public T2 Item2 { get { return item2; } }
+            public T3 Item3 { get { return item3; } }
+            public T4 Item4 { get { return item4; } }
+            public Tuple(T1 item1, T2 item2, T3 item3, T4 item4) {
+                this.item1 = item1;
+                this.item2 = item2;
+                this.item3 = item3;
+                this.item4 = item4;
+            }
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as Tuple<T1, T2, T3, T4>);
+            }
+            public bool Equals(Tuple<T1, T2, T3, T4> obj)
+            {
+                if (obj == null) return false;
+                if (obj == this) return true;
+                return EqualityComparer<T1>.Default.Equals(obj.item1, this.item1)
+                    && EqualityComparer<T2>.Default.Equals(obj.item2, this.item2)
+                    && EqualityComparer<T3>.Default.Equals(obj.item3, this.item3)
+                    && EqualityComparer<T4>.Default.Equals(obj.item4, this.item4);
+            }
+            public override int GetHashCode()
+            {
+                var hash = 13;
+                hash = (hash * -17) + EqualityComparer<T1>.Default.GetHashCode(this.item1);
+                hash = (hash * -17) + EqualityComparer<T2>.Default.GetHashCode(this.item2);
+                hash = (hash * -17) + EqualityComparer<T3>.Default.GetHashCode(this.item3);
+                hash = (hash * -17) + EqualityComparer<T4>.Default.GetHashCode(this.item4);
+                return hash;
+            }
+            public override string ToString()
+            {
+                return "(" + this.item1 + "," + this.item2 + "," + this.item3 + "," + this.item4 + ")";
+            }
+        }
+#endif
+}

--- a/SigilTests/Errors.cs
+++ b/SigilTests/Errors.cs
@@ -159,7 +159,7 @@ namespace SigilTests
 
                 try
                 {
-                    e1.UnboxAny(typeof(string));
+                    e1.UnboxAny(typeof(string)); // MG: UnboxAny is meant to work for ref types
                     Assert.Fail();
                 }
                 catch (ArgumentException e)


### PR DESCRIPTION
.NET 3.5 support and fixes

Also breaks UnboxAny test (because it is a false expectation), and introduces new broken test for complex branching (stack tracing)
