### PR TITLE
Store and load locals by name.

### DIFF
--- a/Sigil/Emit.LoadLocal.cs
+++ b/Sigil/Emit.LoadLocal.cs
@@ -43,5 +43,13 @@ namespace Sigil
 
             return this;
         }
+
+        /// <summary>
+        /// Loads the value in the local with the given name onto the stack.
+        /// </summary>
+        public Emit<DelegateType> LoadLocal(string localName)
+        {
+            return LoadLocal(Locals[localName]);
+        } 
     }
 }

--- a/Sigil/Emit.StoreLocal.cs
+++ b/Sigil/Emit.StoreLocal.cs
@@ -61,5 +61,13 @@ namespace Sigil
 
             return this;
         }
+
+        /// <summary>
+        /// Pops a value off the stack and stores it in the local with the given name.
+        /// </summary>
+        public Emit<DelegateType> StoreLocal(string localName)
+        {
+            return StoreLocal(Locals[localName]);
+        } 
     }
 }

--- a/SigilTests/Errors.cs
+++ b/SigilTests/Errors.cs
@@ -760,7 +760,7 @@ namespace SigilTests
 
                 try
                 {
-                    e1.StoreLocal(null);
+                    e1.StoreLocal((Sigil.Local)null);
                     Assert.Fail();
                 }
                 catch (ArgumentNullException e)
@@ -1739,7 +1739,7 @@ namespace SigilTests
 
                 try
                 {
-                    e1.LoadLocal(null);
+                    e1.LoadLocal((Sigil.Local)null);
                     Assert.Fail();
                 }
                 catch (ArgumentNullException e)


### PR DESCRIPTION
Turns code like this...

```
il.StoreLocal(il.Locals["localName"]);
il.LoadLocal(il.Locals["localName"]);
```

Into this...

```
il.StoreLocal("localName");
il.LoadLocal(il.Locals("localName");
```
