### PR TITLE
Added support for calling base constructors

### DIFF
--- a/Sigil/Emit.cs
+++ b/Sigil/Emit.cs
@@ -1024,6 +1024,13 @@ namespace Sigil
             }
         }
 
+        private void UpdateState(OpCode instr, ConstructorInfo cons, IEnumerable<Type> parameterTypes, TransitionWrapper transitions)
+        {
+            UpdateStackAndInstrStream(instr, transitions, firstParamIsThis: true);
+
+            IL.Emit(instr, cons, parameterTypes);
+        }
+
         private void UpdateState(OpCode instr, ConstructorInfo cons, TransitionWrapper transitions)
         {
             UpdateStackAndInstrStream(instr, transitions);

--- a/Sigil/NonGeneric/Emit.Call.cs
+++ b/Sigil/NonGeneric/Emit.Call.cs
@@ -21,5 +21,17 @@ namespace Sigil.NonGeneric
             InnerEmit.Call(method, arglist);
             return this;
         }
+
+
+        /// <summary>
+        /// Calls the given constructor.  Pops its arguments in reverse order (left-most deepest in the stack).
+        /// 
+        /// The `this` reference should appear before any parameters.
+        /// </summary>
+        public Emit Call(ConstructorInfo constructor)
+        {
+            InnerEmit.Call(constructor);
+            return this;
+        }
     }
 }

--- a/SigilTests/Calls.cs
+++ b/SigilTests/Calls.cs
@@ -12,6 +12,70 @@ namespace SigilTests
     [TestClass, System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class Calls
     {
+        public class ClassWithCtor
+        {
+            public ClassWithCtor(string value)
+            {
+                this.Value = value;
+            }
+
+            public string Value { get; private set; }
+        }
+
+        [TestMethod]
+        public void CallBaseConstructor()
+        {
+            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("SigilTests_CallBaseConstructor"),
+                                                                                     AssemblyBuilderAccess.RunAndCollect);
+
+            ModuleBuilder module = assembly.DefineDynamicModule("RuntimeModule");
+
+            TypeBuilder type = module.DefineType("Class", TypeAttributes.Class, typeof (ClassWithCtor));
+
+            Emit<Action> ctor = Emit<Action>.BuildConstructor(type, MethodAttributes.Public);
+
+            ConstructorInfo baseCtor = typeof (ClassWithCtor).GetConstructor(new[] {typeof(string)});
+
+            ctor.LoadArgument(0);
+            ctor.LoadConstant("abc123");
+            ctor.Call(baseCtor);
+            ctor.Return();
+            ctor.CreateConstructor();
+
+            Type createdType = type.CreateType();
+
+            ClassWithCtor instance = (ClassWithCtor)Activator.CreateInstance(createdType);
+            Assert.IsInstanceOfType(instance, createdType);
+            Assert.AreEqual("abc123", instance.Value);
+        }
+
+        [TestMethod]
+        public void CallBaseConstructorNonGeneric()
+        {
+            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("SigilTests_CallBaseConstructorNonGeneric"),
+                                                                                     AssemblyBuilderAccess.RunAndCollect);
+
+            ModuleBuilder module = assembly.DefineDynamicModule("RuntimeModule");
+
+            TypeBuilder type = module.DefineType("Class", TypeAttributes.Class, typeof(ClassWithCtor));
+
+            Sigil.NonGeneric.Emit ctor = Sigil.NonGeneric.Emit.BuildConstructor(Type.EmptyTypes, type, MethodAttributes.Public);
+
+            ConstructorInfo baseCtor = typeof(ClassWithCtor).GetConstructor(new[] { typeof(string) });
+
+            ctor.LoadArgument(0);
+            ctor.LoadConstant("abc123");
+            ctor.Call(baseCtor);
+            ctor.Return();
+            ctor.CreateConstructor();
+
+            Type createdType = type.CreateType();
+
+            ClassWithCtor instance = (ClassWithCtor)Activator.CreateInstance(createdType);
+            Assert.IsInstanceOfType(instance, createdType);
+            Assert.AreEqual("abc123", instance.Value);
+        }
+
         [TestMethod]
         public void ValueTypeCallIndirect()
         {

--- a/SigilTests/Errors.cs
+++ b/SigilTests/Errors.cs
@@ -3795,12 +3795,29 @@ namespace SigilTests
 
             try
             {
-                e1.Call(null);
+                e1.Call((MethodInfo)null);
                 Assert.Fail();
             }
             catch (ArgumentNullException e)
             {
                 Assert.AreEqual("method", e.ParamName);
+            }
+        }
+
+
+        [TestMethod]
+        public void NullCallConstructor()
+        {
+            var e1 = Emit<Action>.NewDynamicMethod("E1");
+
+            try
+            {
+                e1.Call((ConstructorInfo)null);
+                Assert.Fail();
+            }
+            catch (ArgumentNullException e)
+            {
+                Assert.AreEqual("cons", e.ParamName);
             }
         }
 

--- a/SigilTests/NewObject.cs
+++ b/SigilTests/NewObject.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sigil;
 using System;
 using System.Collections.Generic;
@@ -17,7 +18,7 @@ namespace SigilTests
 
             public ThreeClass(string a, int b, List<double> c)
             {
-                Value = a + " @" + b + " ==> " + string.Join(", ", c);
+                Value = a + " @" + b + " ==> " + string.Join(", ", c.Select(d => d.ToString(CultureInfo.InvariantCulture)));
             }
         }
 


### PR DESCRIPTION
Does not support constructors that use VarArgs.
Added tests for generic and non-generic Emit.
Fixed test that was sensitive to the current CultureInfo (replaced with explicit InvariantCulture)
