### PR TITLE
Bug: Remove tail calls on ByRef functions

### DIFF
--- a/Sigil/Emit.Call.cs
+++ b/Sigil/Emit.Call.cs
@@ -43,6 +43,7 @@ namespace Sigil
                     if (callIx == -1) continue;
                     if (call.TakesManagedPointer()) continue;
                     if (call.TakesTypedReference()) continue;
+                    if (call.TakesByRefArgs()) continue;
 
                     InsertInstruction(callIx, OpCodes.Tailcall);
                     i++;

--- a/Sigil/Impl/BufferedILGenerator.cs
+++ b/Sigil/Impl/BufferedILGenerator.cs
@@ -45,6 +45,13 @@ namespace Sigil.Impl
 
             return instr.MethodParameterTypes.Any(p => p.IsPointer);
         }
+
+        internal bool TakesByRefArgs()
+        {
+            var instr = this;
+
+            return instr.MethodParameterTypes.Any(p => p.IsByRef);
+        }
     }
 
     internal class BufferedILGenerator<DelegateType>

--- a/SigilTests/SigilTests.csproj
+++ b/SigilTests/SigilTests.csproj
@@ -115,6 +115,7 @@
       <DependentUpon>Errors.cs</DependentUpon>
     </Compile>
     <Compile Include="NoVerification.cs" />
+    <Compile Include="Tail.cs" />
     <Compile Include="WriteLine.NonGeneric.cs">
       <DependentUpon>WriteLine.cs</DependentUpon>
     </Compile>

--- a/SigilTests/Tail.cs
+++ b/SigilTests/Tail.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sigil;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SigilTests
+{
+    [TestClass, System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public partial class Tail
+    {
+        const string helloWorld = "Hello, World!";
+
+        static private void BugCausingFuntion(TextWriter writer, ref char[] buffer)
+        {
+            Array.Copy(helloWorld.ToCharArray(), buffer, helloWorld.Length);
+
+            writer.Write(buffer, 0, helloWorld.Length);
+        }
+
+        [TestMethod]
+        public void TailBugWithRefArgs()
+        {
+            var bugCausingFuntion= typeof(Tail).GetMethod("BugCausingFuntion", BindingFlags.Static | BindingFlags.NonPublic);
+
+            var emit = Emit<Action<TextWriter>>.NewDynamicMethod();
+
+            var buffer = emit.DeclareLocal<char[]>();
+            emit.LoadConstant(helloWorld.Length+1);
+            emit.NewArray<char>();
+            emit.StoreLocal(buffer);
+
+            emit.LoadArgument(0);
+            emit.LoadLocalAddress(buffer);
+            emit.Call(bugCausingFuntion);
+            emit.Return();
+            
+            var f = emit.CreateDelegate();
+
+            var sw = new StringWriter();
+            f(sw);
+
+            var result = sw.GetStringBuilder().ToString();
+
+            Assert.AreEqual(result, helloWorld);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Found whilst working on Jil, after changing the _WriteEncodedString\* functions to take the "ref char[] buffer". It caused a few of the Jil tests to fail in the test suite when run in debug build (although they passed if you tried to debug them, and they ran fine in the release build test suite.)
