### PR TITLE
Make reused local initialization optional

### DIFF
--- a/Sigil/Emit.Locals.cs
+++ b/Sigil/Emit.Locals.cs
@@ -39,6 +39,20 @@ namespace Sigil
         /// </summary>
         public Local DeclareLocal(Type type, string name = null)
         {
+            return DeclareLocal(type, name, initializeReused: true);
+        }
+
+        /// <summary>
+        /// Declare a new local of the given type in the current method.
+        /// 
+        /// Name is optional, and only provided for debugging purposes.  It has no
+        /// effect on emitted IL.
+        /// 
+        /// Be aware that each local takes some space on the stack, inefficient use of locals
+        /// could lead to StackOverflowExceptions at runtime.
+        /// </summary>
+        public Local DeclareLocal(Type type, string name, bool initializeReused)
+        {
             if (type == null)
             {
                 throw new ArgumentNullException("type");
@@ -81,7 +95,7 @@ namespace Sigil
 
             // we need to initialize this local to it's default value, because otherwise
             //   it might be read from to get some non-sense
-            if (existingLocal != null)
+            if (existingLocal != null && initializeReused)
             {
                 if (!type.IsValueType)
                 {

--- a/SigilTests/Local.cs
+++ b/SigilTests/Local.cs
@@ -172,5 +172,31 @@ namespace SigilTests
                 Assert.AreEqual(default(DateTime), d1());
             }
         }
+
+        [TestMethod]
+        public void ReinitializeOptOut()
+        {
+            var e1 = Emit<Func<int>>.NewDynamicMethod();
+
+            using (var a = e1.DeclareLocal<int>("a"))
+            {
+                e1.LoadLocal(a);
+                e1.LoadConstant(1);
+                e1.Add();
+            }
+
+            using (var b = e1.DeclareLocal(typeof(int), "b", initializeReused: false))
+            {
+                e1.StoreLocal(b);
+                e1.LoadLocal(b);
+                e1.Return();
+            }
+
+            string instrs;
+            var d1 = e1.CreateDelegate(out instrs);
+
+            Assert.AreEqual(1, d1());
+            Assert.AreEqual("ldloc.0\r\nldc.i4.1\r\nadd\r\nstloc.0\r\nldloc.0\r\nret\r\n", instrs);
+        }
     }
 }


### PR DESCRIPTION
The local reuse changes in 4.3.1 are reasonable and safe.  However, as a library for crafting IL this safety feature should be optional; the author should be able to take responsibility for initializing the local before reading.

Examples:

---
Safe default:
```csharp
using (var a = e1.DeclareLocal(typeof(int), "a"))
{
    // do something with local variable a
}

using (var b = e1.DeclareLocal(typeof(int), "b"))
{
    e1.LoadConstant(1);
    e1.StoreLocal(b);
    // do something with local variable b
}
```
IL:
```
ldc.i4.0
stloc.0
ldc.i4.1
stloc.0
```

---
Opt out:
```csharp
using (var a = e1.DeclareLocal(typeof(int), "a"))
{
    // do something with local variable a
}

using (var b = e1.DeclareLocal(typeof(int), "b", initializeReused: false))
{
    e1.LoadConstant(1);
    e1.StoreLocal(b);
    // do something with local variable b
}
```
IL:
```
ldc.i4.1
stloc.0
```