### PR TITLE
Fix InstructionSize.Get for switch

### DIFF
--- a/Sigil/Impl/BufferedILGenerator.cs
+++ b/Sigil/Impl/BufferedILGenerator.cs
@@ -728,7 +728,7 @@ namespace Sigil.Impl
                     localOp = newOpcode;
                 };
 
-            InstructionSizes.Add(() => InstructionSize.Get(localOp));
+            InstructionSizes.Add(() => InstructionSize.Get(localOp, labels));
 
             LengthCache.Clear();
 

--- a/Sigil/Impl/InstructionSize.cs
+++ b/Sigil/Impl/InstructionSize.cs
@@ -5,7 +5,7 @@ namespace Sigil.Impl
 {
     internal static class InstructionSize
     {
-        public static int Get(OpCode op)
+        public static int Get(OpCode op, Sigil.Label[] labels = null)
         {
             var baseSize = op.Size;
             int operandSize;
@@ -21,7 +21,7 @@ namespace Sigil.Impl
                 case OperandType.InlineR: operandSize = 8; break;
                 case OperandType.InlineSig: operandSize = 4; break;
                 case OperandType.InlineString: operandSize = 4; break;
-                case OperandType.InlineSwitch: operandSize = 4; break;
+                case OperandType.InlineSwitch: operandSize = 4 + labels.Length * 4; break;
                 case OperandType.InlineTok: operandSize = 4; break;
                 case OperandType.InlineType: operandSize = 4; break;
                 case OperandType.InlineVar: operandSize = 2; break;

--- a/SigilTests/Branches.cs
+++ b/SigilTests/Branches.cs
@@ -571,5 +571,40 @@ namespace SigilTests
 
             Assert.AreEqual(314, del());
         }
+
+        [TestMethod]
+        public void BigSwitch()
+        {
+            var e1 = Emit<Func<uint, uint>>.NewDynamicMethod();
+
+            // prep labels
+            var before = e1.DefineLabel();
+            var first = e1.DefineLabel();
+            var defaultLabel = e1.DefineLabel();
+
+            // prep switch targets
+            var labels = new Sigil.Label[30];
+            for (int i = 1; i < labels.Length; i++)
+                labels[i] = defaultLabel;
+            labels[0] = first;
+
+            // emit trivial switch
+            e1.MarkLabel(before);
+            e1.LoadArgument(0);
+            e1.Switch(labels);
+
+            e1.MarkLabel(defaultLabel);
+            e1.LoadConstant(0u);
+            e1.StoreArgument(0);
+            e1.Branch(before);
+
+            e1.MarkLabel(first);
+            e1.LoadArgument(0);
+            e1.Return();
+
+            var del = e1.CreateDelegate();
+
+            Assert.AreEqual(0u, del(42));
+        }
     }
 }


### PR DESCRIPTION
The labels used with a switch instruction were not considered when calculating instruction size for `OptimizationOptions.EnableBranchPatching`.  The short branch instruction could incorrectly be used leading to error like: ``System.NotSupportedException: Illegal one-byte branch at position: 22. Requested branch was: 586.``

https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.switch%28v=vs.110%29.aspx