### PR TITLE
Add overloads to allow pointer loads of unbaked functions

### DIFF
--- a/Sigil/Emit.LoadFunctionPointer.cs
+++ b/Sigil/Emit.LoadFunctionPointer.cs
@@ -21,17 +21,47 @@ namespace Sigil
 
             var parameters = method.GetParameters();
 
-            var paramList = ((LinqArray<ParameterInfo>)parameters).Select(p => p.ParameterType).ToList();
+            var paramList = ((LinqArray<ParameterInfo>)parameters).Select(p => p.ParameterType).ToArray();
 
+            return InnerLoadFunctionPointer(method, paramList);
+        }
+
+
+        /// <summary>
+        /// Pushes a pointer to the given function onto the stack, as a native int.
+        /// 
+        /// To resolve a method at runtime using an object, use LoadVirtualFunctionPointer instead.
+        /// 
+        /// This method is provided as MethodBuilder cannot be inspected for parameter information at runtime.  If the passed parameterTypes
+        /// do not match the given method, the produced code will be invalid.
+        /// </summary>
+        public Emit<DelegateType> LoadFunctionPointer(MethodBuilder method, Type[] parameterTypes)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if(parameterTypes == null)
+            {
+                throw new ArgumentNullException(nameof(parameterTypes));
+            }
+
+
+            return InnerLoadFunctionPointer(method, parameterTypes);
+        }
+
+        Emit<DelegateType> InnerLoadFunctionPointer(MethodInfo method, Type[] parameterTypes)
+        {
             var type =
                 TypeOnStack.GetKnownFunctionPointer(
                     method.CallingConvention,
                     HasFlag(method.CallingConvention, CallingConventions.HasThis) ? method.DeclaringType : null,
                     method.ReturnType,
-                    paramList.ToArray()
+                    parameterTypes
                 );
 
-            UpdateState(OpCodes.Ldftn, method, paramList.AsEnumerable(), Wrap(new[] { new StackTransition(new TypeOnStack[0], new[] { type }) }, "LoadFunctionPointer"));
+            UpdateState(OpCodes.Ldftn, method, parameterTypes, Wrap(new[] { new StackTransition(new TypeOnStack[0], new[] { type }) }, "LoadFunctionPointer"));
 
             return this;
         }

--- a/Sigil/Emit.LoadVirtualFunctionPointer.cs
+++ b/Sigil/Emit.LoadVirtualFunctionPointer.cs
@@ -1,5 +1,6 @@
 ﻿using Sigil.Impl;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -24,13 +25,49 @@ namespace Sigil
                 throw new ArgumentException("Only non-static methods can be passed to LoadVirtualFunctionPointer, found " + method);
             }
 
-            var thisType =
-                HasFlag(method.CallingConvention, CallingConventions.HasThis) ?
-                    method.DeclaringType :
-                    null;
 
             var parameters = method.GetParameters();
-            var paramList = LinqAlternative.Select(parameters, p => p.ParameterType).ToList();
+            var paramList = LinqAlternative.Select(parameters, p => p.ParameterType).ToArray();
+
+            return InnerLoadVirtualFunctionPointer(method, paramList);
+        }
+
+        /// <summary>
+        /// Pops an object reference off the stack, and pushes a pointer to the given method's implementation on that object.
+        /// 
+        /// For static or non-virtual functions, use LoadFunctionPointer
+        /// 
+        /// This method is provided as MethodBuilder cannot be inspected for parameter information at runtime.  If the passed parameterTypes
+        /// do not match the given method, the produced code will be invalid.
+        /// </summary>
+        public Emit<DelegateType> LoadVirtualFunctionPointer(MethodBuilder method, Type[] parameterTypes)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (method.IsStatic)
+            {
+                throw new ArgumentException("Only non-static methods can be passed to LoadVirtualFunctionPointer, found " + method);
+            }
+
+            if(parameterTypes == null)
+            {
+                throw new ArgumentNullException(nameof(parameterTypes));
+            }
+
+            return InnerLoadVirtualFunctionPointer(method, parameterTypes);
+        }
+
+        Emit<DelegateType> InnerLoadVirtualFunctionPointer(MethodInfo method, Type[] parameterTypes)
+        {
+            var thisType =
+               HasFlag(method.CallingConvention, CallingConventions.HasThis) ?
+                   method.DeclaringType :
+                   null;
+
+            var paramList = new List<Type>(parameterTypes);
 
             var declaring = method.DeclaringType;
 
@@ -49,13 +86,13 @@ namespace Sigil
                     paramList.ToArray()
                 );
 
-            var transitions = 
+            var transitions =
                 new[]
                 {
                     new StackTransition(new [] { declaring }, new [] { typeof(NativeIntType) })
                 };
 
-            UpdateState(OpCodes.Ldvirtftn, method, LinqAlternative.Select(parameters, p => p.ParameterType).AsEnumerable(), Wrap(transitions, "LoadVirtualFunctionPointer"));
+            UpdateState(OpCodes.Ldvirtftn, method, parameterTypes, Wrap(transitions, "LoadVirtualFunctionPointer"));
 
             return this;
         }

--- a/Sigil/NonGeneric/Emit.LoadFunctionPointer.cs
+++ b/Sigil/NonGeneric/Emit.LoadFunctionPointer.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
 
 namespace Sigil.NonGeneric
 {
@@ -12,6 +14,20 @@ namespace Sigil.NonGeneric
         public Emit LoadFunctionPointer(MethodInfo method)
         {
             InnerEmit.LoadFunctionPointer(method);
+            return this;
+        }
+
+        /// <summary>
+        /// Pushes a pointer to the given function onto the stack, as a native int.
+        /// 
+        /// To resolve a method at runtime using an object, use LoadVirtualFunctionPointer instead.
+        /// 
+        /// This method is provided as MethodBuilder cannot be inspected for parameter information at runtime.  If the passed parameterTypes
+        /// do not match the given method, the produced code will be invalid.
+        /// </summary>
+        public Emit LoadFunctionPointer(MethodBuilder method, Type[] parameterTypes)
+        {
+            InnerEmit.LoadFunctionPointer(method, parameterTypes);
             return this;
         }
     }

--- a/Sigil/NonGeneric/Emit.LoadVirtualFunctionPointer.cs
+++ b/Sigil/NonGeneric/Emit.LoadVirtualFunctionPointer.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
 
 namespace Sigil.NonGeneric
 {
@@ -12,6 +14,20 @@ namespace Sigil.NonGeneric
         public Emit LoadVirtualFunctionPointer(MethodInfo method)
         {
             InnerEmit.LoadVirtualFunctionPointer(method);
+            return this;
+        }
+
+        /// <summary>
+        /// Pops an object reference off the stack, and pushes a pointer to the given method's implementation on that object.
+        /// 
+        /// For static or non-virtual functions, use LoadFunctionPointer.
+        /// 
+        /// This method is provided as MethodBuilder cannot be inspected for parameter information at runtime.  If the passed parameterTypes
+        /// do not match the given method, the produced code will be invalid.
+        /// </summary>
+        public Emit LoadVirtualFunctionPointer(MethodBuilder method, Type[] parameterTypes)
+        {
+            InnerEmit.LoadVirtualFunctionPointer(method, parameterTypes);
             return this;
         }
     }

--- a/SigilTests/LoadFunctionPointer.NonGeneric.cs
+++ b/SigilTests/LoadFunctionPointer.NonGeneric.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sigil.NonGeneric;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection.Emit;
+using System.Reflection;
+
+namespace SigilTests
+{
+    public partial class LoadFunctionPointer
+    {
+        [TestMethod]
+        public void CanValidateUnbakedNonGeneric()
+        {
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("MethodBuilders"), AssemblyBuilderAccess.Run);
+            var mod = asm.DefineDynamicModule("Mod");
+            var tb = mod.DefineType("Type");
+
+            var targetMethodBuilder = Emit.BuildStaticMethod(typeof(void), new Type[0], tb, "UnbakedFunction", MethodAttributes.Public);
+            targetMethodBuilder.Return();
+            var targetMethod = targetMethodBuilder.CreateMethod();
+
+            var testMethod = Emit.BuildStaticMethod(typeof(void), new Type[0], tb, "Create", MethodAttributes.Public | MethodAttributes.Static);
+            testMethod.LoadFunctionPointer(targetMethod, new Type[0]);
+            testMethod.Pop();//dump useless obj
+            testMethod.Return();
+
+            testMethod.CreateMethod();//will throw on failure
+        }        
+    }
+}

--- a/SigilTests/LoadFunctionPointer.cs
+++ b/SigilTests/LoadFunctionPointer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sigil;
+
+namespace SigilTests
+{
+    [TestClass]
+    public partial class LoadFunctionPointer
+    {
+        [TestMethod]
+        public void CanLoadUnbaked()
+        {
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("MethodBuilders"), AssemblyBuilderAccess.Run);
+            var mod = asm.DefineDynamicModule("Mod");
+            var tb = mod.DefineType("Type");
+
+            var mb = Emit<Action>.BuildInstanceMethod(tb, "UnbakedFunction", MethodAttributes.Public);
+            mb.Return();
+            var meth = mb.CreateMethod();
+
+            var createProxy = Emit<Func<object>>.BuildStaticMethod(tb, "Create", MethodAttributes.Public | MethodAttributes.Static);
+            createProxy.LoadFunctionPointer(meth, new Type[0]);
+            createProxy.Return();
+
+            createProxy.CreateMethod();//will throw on failure
+        }
+    }
+}

--- a/SigilTests/LoadVirtualFunctionPointer.NonGeneric.cs
+++ b/SigilTests/LoadVirtualFunctionPointer.NonGeneric.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sigil.NonGeneric;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection.Emit;
+using System.Reflection;
+
+namespace SigilTests
+{
+    public partial class LoadVirtualFunctionPointer
+    {
+        [TestMethod]
+        public void CanValidateUnbakedNonGeneric()
+        {
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("MethodBuilders"), AssemblyBuilderAccess.Run);
+            var mod = asm.DefineDynamicModule("Mod");
+            var tb = mod.DefineType("Type");
+
+            var cb = Emit.BuildConstructor(new Type[0], tb, MethodAttributes.Public);
+            cb.Return();
+            var cons = cb.CreateConstructor();
+
+            var targetMethodBuilder = Emit.BuildInstanceMethod(typeof(void), new Type[0], tb, "UnbakedFunction", MethodAttributes.Public);
+            targetMethodBuilder.Return();
+            var targetMethod = targetMethodBuilder.CreateMethod();
+
+            var testMethod = Emit.BuildStaticMethod(typeof(void), new Type[0], tb, "Create", MethodAttributes.Public | MethodAttributes.Static);
+
+            testMethod.NewObject(cons, new Type[0]);
+
+            testMethod.LoadVirtualFunctionPointer(targetMethod, new Type[0]);
+            testMethod.Pop();
+            testMethod.Return();
+
+            testMethod.CreateMethod();//will throw on failure
+        }
+    }
+}

--- a/SigilTests/LoadVirtualFunctionPointer.cs
+++ b/SigilTests/LoadVirtualFunctionPointer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sigil;
+
+namespace SigilTests
+{
+    [TestClass]
+    public partial class LoadVirtualFunctionPointer
+    {
+        [TestMethod]
+        public void CanValidateUnbaked()
+        {
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("MethodBuilders"), AssemblyBuilderAccess.Run);
+            var mod = asm.DefineDynamicModule("Mod");
+            var tb = mod.DefineType("Type");
+
+            var cb = Emit<Action>.BuildConstructor(tb, MethodAttributes.Public);
+            cb.Return();
+            var cons = cb.CreateConstructor();
+
+            var mb = Emit<Action>.BuildInstanceMethod(tb, "UnbakedFunction", MethodAttributes.Public);
+            mb.Return();
+            var meth = mb.CreateMethod();
+
+            var createProxy = Emit<Action>.BuildStaticMethod(tb, "Create", MethodAttributes.Public | MethodAttributes.Static);
+            createProxy.NewObject(cons, new Type[0]);
+            createProxy.LoadVirtualFunctionPointer(meth, new Type[0]);
+            createProxy.Pop();//dump the useless value
+            createProxy.Return();
+
+            createProxy.CreateMethod();//will throw on failure
+        }
+    }
+}

--- a/SigilTests/SigilTests.csproj
+++ b/SigilTests/SigilTests.csproj
@@ -51,7 +51,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -120,6 +122,14 @@
     <Compile Include="TypeInitializer.NonGeneric.cs">
       <DependentUpon>TypeInitializer.cs</DependentUpon>
     </Compile>
+    <Compile Include="LoadFunctionPointer.cs" />
+    <Compile Include="LoadFunctionPointer.NonGeneric.cs">
+      <DependentUpon>LoadFunctionPointer.cs</DependentUpon>
+    </Compile>
+    <Compile Include="LoadVirtualFunctionPointer.cs" />
+	<Compile Include="LoadVirtualFunctionPointer.NonGeneric.cs">
+	  <DependentUpon>LoadVirtualFunctionPointer.cs</DependentUpon>
+	</Compile>
     <Compile Include="WriteLine.NonGeneric.cs">
       <DependentUpon>WriteLine.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
Similar to #28.

Please note, the following things :

- I used nameof() in a couple places. 

- In the new inner* methods i did not use the AsEnumerable or copy the data for the call to UpdateState

- What about the shorthand stuff, should i add overloads there?