### PR TITLE
Don't insert tail calls when returns are mismatched

### DIFF
--- a/Sigil/Emit.Call.cs
+++ b/Sigil/Emit.Call.cs
@@ -10,6 +10,8 @@ namespace Sigil
     {
         private void InjectTailCall()
         {
+            var delegateReturnsVoid = ReturnType.Type == typeof(void);
+
             for (var i = 0; i < IL.Index; i++)
             {
                 var instr = IL[i];
@@ -46,6 +48,9 @@ namespace Sigil
                     if (call.TakesTypedReference()) continue;
 #endif
                     if (call.TakesByRefArgs()) continue;
+
+                    var callReturnsVoid = call.MethodReturnType == typeof(void);
+                    if (delegateReturnsVoid != callReturnsVoid) continue;
 
                     InsertInstruction(callIx, OpCodes.Tailcall);
                     i++;


### PR DESCRIPTION
There's a small, but pretty nasty, bug in how Sigil inserts tail calls. It doesn't take into consideration that the function being called returns void while the delegate has a non-void return type.

The specific scenario I discovered this through is by creating a simple dynamic method that instantiates a new object, sets a property on it, and returns it.

```csharp
class ClassWithProperty
{
    public string String { get; set; }
}

Func<ClassWithProperty> Generate()
{
    var emit = Emit<Func<ClassWithProperty>>.NewDynamicMethod();

    emit.NewObject<ClassWithProperty>(); // obj

    var prop = typeof(ClassWithProperty).GetProperty("String");
    emit.Duplicate();                   // obj obj
    emit.LoadConstant("please work");   // obj obj string
    emit.CallVirtual(prop.SetMethod);   // obj

    emit.Return();

    return emit.CreateDelegate();
}
```

If you actually call the returned delegate, it blows up with an `InvalidProgramException` because the IL generated is:

```
IL_0000: newobj     Void .ctor()/SigilTest.ClassWithProperty
IL_0005: dup        
IL_0006: ldstr      "please work"
IL_000b: tail.      
IL_000d: callvirt   Void set_String(System.String)/SigilTest.ClassWithProperty
IL_0012: ret       
```

The tail call doesn't make any sense because `set_String` returns `void`, whereas the delegate has a non-void return type.

I've added a test for this, and created a fix by checking if they have a mismatch in void's. The inverse scenario where the delegate is void, but the method it's calling right before a return statement is non-void, doesn't actually make any sense. I'm hoping Sigil validates for that elsewhere, though I didn't investigate.

Feel free to modify the fix to your liking...