### PR TITLE
.NET Core RC2 Upgrade

### DIFF
--- a/Sigil/Emit.LoadField.cs
+++ b/Sigil/Emit.LoadField.cs
@@ -28,12 +28,8 @@ namespace Sigil
             {
                 throw new ArgumentException("unaligned cannot be used with static fields");
             }
-
-#if COREFXTODO // see https://github.com/dotnet/corefx/issues/4543 item 3
-            var useVolatile = isVolatile ?? false;
-#else
+            
             var useVolatile = isVolatile ?? ExtensionMethods.IsVolatile(field);
-#endif
 
             if (!field.IsStatic)
             {

--- a/Sigil/Impl/ExtensionMethods.cs
+++ b/Sigil/Impl/ExtensionMethods.cs
@@ -21,8 +21,7 @@ namespace Sigil.Impl
 
             return "aeiou".IndexOf(c) != -1;
         }
-
-#if !COREFXTODO // see https://github.com/dotnet/corefx/issues/4543 item 3 - would rather not offer the API than be wrong
+        
         public static bool IsVolatile(FieldInfo field)
         {
             // field builder doesn't implement GetRequiredCustomModifiers
@@ -30,7 +29,6 @@ namespace Sigil.Impl
 
             return Array.IndexOf(field.GetRequiredCustomModifiers(), typeof(System.Runtime.CompilerServices.IsVolatile)) >= 0;
         }
-#endif
 
         public static bool IsPrefix(OpCode op)
         {

--- a/Sigil/Sigil.xproj
+++ b/Sigil/Sigil.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>3f959ab7-a1c2-41da-a1f3-981ea89a0067</ProjectGuid>
     <RootNamespace>Sigil</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Sigil/project.json
+++ b/Sigil/project.json
@@ -1,58 +1,49 @@
 ﻿{
+  "packOptions": {
+    "summary": "A fail-fast validation helper for .NET CIL generation.",
+    "tags": [ "cil msil il bytecode" ],
+    "owners": [ "kmontrose" ],
+    "releaseNotes": ".NET Core RC2 update",
+    "requireLicenseAcceptance": false,
+    "projectUrl": "https://github.com/kevin-montrose/Sigil",
+    "licenseUrl": "http://opensource.org/licenses/MS-PL",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/kevin-montrose/Sigil"
+    }    
+  },
   "version": "4.6.1",
   "description": "A fail-fast validation helper for .NET CIL generation.",
   "authors": [ "kmontrose" ],
-  "tags": [ "cil msil il bytecode" ],
-  "projectUrl": "https://github.com/kevin-montrose/Sigil",
-  "licenseUrl": "http://opensource.org/licenses/MS-PL",
-  "releaseNotes": "Fix bugs with tailcalls, verification around object <-> ValueType relations, and add new options for loading function pointers.",
   "copyright": "2013-2016 Kevin Montrose",
-  "requireLicenseAcceptance": false,
-  "compilationOptions": {
+  "buildOptions": {
     "keyFile": "../Sigil/Properties/Sigil.snk"
   },
   "frameworks": {
     "net20": {
-      "compilationOptions": { "define": [ "NET20" ] }
+      "buildOptions": { "define": [ "NET20" ] }
     },
     "net30": {
-      "compilationOptions": { "define": [ "NET30" ] }
+      "buildOptions": { "define": [ "NET30" ] }
     },
     "net35": {
-      "compilationOptions": { "define": [ "NET35" ] }
+      "buildOptions": { "define": [ "NET35" ] }
     },
     "net40": {
-      "compilationOptions": { "define": [ "NET40" ] }
+      "buildOptions": { "define": [ "NET40" ] }
     },
     "net45": {
-      "compilationOptions": { "define": [ "NET45" ] }
+      "buildOptions": { "define": [ "NET45" ] }
     },
-    "dotnet5.2": {
-      "compilationOptions": { "define": [ "COREFX", "COREFXTODO" ] },
+    "netstandard1.5": {
+      "buildOptions": { "define": [ "COREFX", "COREFXTODO" ] },
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-*",
-        "System.Collections": "4.0.11-*",
-        "System.Reflection.Emit": "4.0.1-*",
-        "System.Reflection.Emit.ILGeneration": "4.0.1-*",
-        "System.Reflection.Emit.Lightweight": "4.0.1-*",
-        "System.Reflection.TypeExtensions": "4.1.0-*",
-        "System.Text.RegularExpressions": "4.0.11-*",
-        "System.Console": "4.0.0-*",
-        "System.Reflection.Metadata": "1.1.1-*"
-      }
-    },
-    "dotnet5.4": {
-      "compilationOptions": { "define": [ "COREFX", "COREFXTODO" ] },
-      "dependencies": {
-        "Microsoft.CSharp": "4.0.1-*",
-        "System.Collections": "4.0.11-*",
-        "System.Reflection.Emit": "4.0.1-*",
-        "System.Reflection.Emit.ILGeneration": "4.0.1-*",
-        "System.Reflection.Emit.Lightweight": "4.0.1-*",
-        "System.Reflection.TypeExtensions": "4.1.0-*",
-        "System.Text.RegularExpressions": "4.0.11-*",
-        "System.Console": "4.0.0-*",
-        "System.Reflection.Metadata": "1.1.1-*"
+        "NETStandard.Library": "1.5.0-rc2-24027",
+        "System.Reflection.Emit": "4.0.1-rc2-24027",
+        "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-24027",
+        "System.Reflection.Emit.Lightweight": "4.0.1-rc2-24027",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",        
+        "System.Reflection.Metadata": "1.3.0-rc2-24027*"
       }
     }
   }

--- a/SigilTests.DNX/SigilTests.DNX.xproj
+++ b/SigilTests.DNX/SigilTests.DNX.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>ac7e3c9d-9b25-4da8-9d1d-fd7ee39a6a9e</ProjectGuid>
     <RootNamespace>SigilTests.DNX</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/SigilTests.DNX/project.json
+++ b/SigilTests.DNX/project.json
@@ -2,33 +2,38 @@
   "version": "1.0.0-*",
   "description": "SigilTests Console Application",
   "authors": [ "Kevin Montrose" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
-  "compile": [
-    "**/*.cs",
-    "../SigilTests/**/*.cs"
-  ],
   "dependencies": {
     "Sigil": { "target": "project" }
   },
-  "compilationOptions": { "allowUnsafe": true },
+  "buildOptions": { 
+    "allowUnsafe": true ,
+    "emitEntryPoint": true,
+    "compile": {
+      "include":[
+        "**/*.cs",
+        "../SigilTests/**/*.cs"
+      ]
+    }
+  },
   "commands": {
     "test": "xunit.runner.dnx"
   },
-
+  "testRunner": "xunit",
   "frameworks": {
-    "dnxcore50": {
-      "compilationOptions": {
+    "netcoreapp1.0": {
+      "imports": [ "dnxcore50", "portable-net45+win8" ],
+      "buildOptions": {
         "define": [ "COREFX", "COREFXTODO" ],
         "defineForCrazy": [ "COREFX", "COREFXTODO", "WTFDNXTEST" ]
       },
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-*",
-        "System.Collections": "4.0.11-*",
-        "System.Console": "4.0.0-*",
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        },
+        "Microsoft.CSharp": "4.0.1-rc2-24027",
         "xunit": "2.1.0",
-        "xunit.runner.dnx": "2.1.0-*"
+        "dotnet-test-xunit": "1.0.0-rc2-*"
       }
     }
   }

--- a/SigilTests/Volatile.cs
+++ b/SigilTests/Volatile.cs
@@ -20,7 +20,7 @@ namespace SigilTests
             public volatile int A;
 #pragma warning restore CS0649
         }
-#if !COREFXTODO // see https://github.com/dotnet/corefx/issues/4543 item 3
+
         [TestMethod]
         public void Simple()
         {
@@ -35,7 +35,7 @@ namespace SigilTests
             Assert.AreEqual(1, d1(new SimpleClass { A = 1 }));
             Assert.IsTrue(instrs.Contains("volatile."));
         }
-#endif
+
         class NoneClass
         {
             public int A;

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.0-rc1-final"
+    "version": "1.0.0-preview1-002702"
   }
 }


### PR DESCRIPTION
This updates the refs and bits available in .NET Core RC2. I think we can bring back a bit more functionality but that'll take some more time to dig. First pass is to unblock a Jil release after this one.

All but 2 unit tests pass (and they break on non-core as well): 
- `SigilTests.Multiply.UnsignedOverflow`
- `SigilTests.Multiply.UnsignedOverflowNonGeneric`

Build via `dotnet build`
Pack via: `dotnet pack -c Release`

Note: I did not bump the version here - leaving that to Kevin.