### PR TITLE
Issues with NonGeneric.Emit.Call

### DIFF
--- a/Sigil/NonGeneric/Emit.Call.cs
+++ b/Sigil/NonGeneric/Emit.Call.cs
@@ -63,7 +63,8 @@ namespace Sigil.NonGeneric
                 methodInfo = dynMethod;
             }
 
-            return Call(methodInfo, arglist);
+            InnerEmit.Call(emit.InnerEmit, arglist);
+            return this;
         }
     }
 }


### PR DESCRIPTION
Hi,

The function Sigil.NonGeneric.Emit.Call ends up calling this overload of Emit<NonGenericPlaceholderDelegate>.Call:
 `public Emit<DelegateType> Call(MethodInfo method, Type[] arglist = null)`

That overload is for already builded types and, in fact, the inner MethodBuilder object does not seems to like the call to GetParameters() (NotSupportedException -> Type has not beed created).

Is it possible to fix this calling the other overload of Emit<NonGenericPlaceholderDelegate>.Call?

Thanks!