### PR TITLE
Added LoadConstant overload with ConstructorInfo parameter

### DIFF
--- a/Sigil/Disassembler.cs
+++ b/Sigil/Disassembler.cs
@@ -2511,6 +2511,7 @@ namespace Sigil
             {
                 var asFld = operands[0] as FieldInfo;
                 var asMtd = operands[0] as MethodInfo;
+                var asCtor = operands[0] as ConstructorInfo;
                 var asType = operands[0] as Type;
 
                 if (asFld != null)
@@ -2532,6 +2533,17 @@ namespace Sigil
                             OpCode = op,
                             Parameters = new object[] { asMtd },
                             Replay = emit => emit.LoadConstant(asMtd)
+                        };
+                }
+
+                if (asCtor != null)
+                {
+                    return
+                        new Operation<DelegateType>
+                        {
+                            OpCode = op,
+                            Parameters = new object[] { asCtor },
+                            Replay = emit => emit.LoadConstant(asCtor)
                         };
                 }
 

--- a/Sigil/Emit.LoadConstant.cs
+++ b/Sigil/Emit.LoadConstant.cs
@@ -170,6 +170,21 @@ namespace Sigil
         }
 
         /// <summary>
+        /// Push a constant RuntimeMethodHandle onto the stack.
+        /// </summary>
+        public Emit<DelegateType> LoadConstant(ConstructorInfo constructor)
+        {
+            if (constructor == null)
+            {
+                throw new ArgumentNullException("constructor");
+            }
+
+            UpdateState(OpCodes.Ldtoken, constructor, TypeHelpers.EmptyTypes, Wrap(StackTransition.Push<RuntimeMethodHandle>(), "LoadConstant"));
+
+            return this;
+        }
+
+        /// <summary>
         /// Push a constant RuntimeTypeHandle onto the stack.
         /// </summary>
         public Emit<DelegateType> LoadConstant<Type>()

--- a/Sigil/EmitShorthand.cs
+++ b/Sigil/EmitShorthand.cs
@@ -955,6 +955,14 @@ namespace Sigil
             return this;
         }
 
+        /// <summary cref="M:Sigil.Emit`1.LoadConstant(System.Reflection.ConstructorInfo)" />
+        public EmitShorthand<DelegateType> Ldtoken(ConstructorInfo constructor)
+        {
+            InnerEmit.LoadConstant(constructor);
+
+            return this;
+        }
+
         /// <summary cref="M:Sigil.Emit`1.LoadConstant(System.Type)" />
         public EmitShorthand<DelegateType> Ldtoken<Type>()
         {

--- a/Sigil/NonGeneric/Emit.LoadConstant.cs
+++ b/Sigil/NonGeneric/Emit.LoadConstant.cs
@@ -98,6 +98,15 @@ namespace Sigil.NonGeneric
         }
 
         /// <summary>
+        /// Push a constant RuntimeMethodHandle onto the stack.
+        /// </summary>
+        public Emit LoadConstant(ConstructorInfo constructor)
+        {
+            InnerEmit.LoadConstant(constructor);
+            return this;
+        }
+
+        /// <summary>
         /// Push a constant RuntimeTypeHandle onto the stack.
         /// </summary>
         public Emit LoadConstant<Type>()

--- a/Sigil/NonGeneric/EmitShorthand.cs
+++ b/Sigil/NonGeneric/EmitShorthand.cs
@@ -961,6 +961,14 @@ namespace Sigil.NonGeneric
             return this;
         }
 
+        /// <summary cref="M:Sigil.Emit.NonGeneric.Emit`1.LoadConstant(System.Reflection.ConstructorInfo)" />
+        public EmitShorthand Ldtoken(ConstructorInfo constructor)
+        {
+            InnerEmit.LoadConstant(constructor);
+
+            return this;
+        }
+
         /// <summary cref="M:Sigil.Emit.NonGeneric.Emit`1.LoadConstant(System.Type)" />
         public EmitShorthand Ldtoken<Type>()
         {

--- a/SigilTests/Errors.cs
+++ b/SigilTests/Errors.cs
@@ -2673,6 +2673,20 @@ namespace SigilTests
 
                 try
                 {
+                    e1.LoadConstant((ConstructorInfo)null);
+                    Assert.Fail();
+                }
+                catch (ArgumentNullException e)
+                {
+                    Assert.AreEqual("constructor", e.ParamName);
+                }
+            }
+
+            {
+                var e1 = Emit<Action>.NewDynamicMethod();
+
+                try
+                {
                     e1.LoadConstant((FieldInfo)null);
                     Assert.Fail();
                 }

--- a/SigilTests/LoadConstants.NonGeneric.cs
+++ b/SigilTests/LoadConstants.NonGeneric.cs
@@ -172,6 +172,18 @@ namespace SigilTests
         }
 
         [TestMethod]
+        public void ConstructorNonGeneric()
+        {
+            var e1 = Emit.NewDynamicMethod(typeof(RuntimeMethodHandle), System.Type.EmptyTypes);
+            e1.LoadConstant(typeof(string).GetConstructor(new []{typeof(char), typeof(int)}));
+            e1.Return();
+
+            var d1 = e1.CreateDelegate<Func<RuntimeMethodHandle>>();
+
+            Assert.IsNotNull(d1());
+        }
+
+        [TestMethod]
         public void FieldNonGeneric()
         {
             var e1 = Emit.NewDynamicMethod(typeof(RuntimeFieldHandle), System.Type.EmptyTypes);

--- a/SigilTests/LoadConstants.cs
+++ b/SigilTests/LoadConstants.cs
@@ -172,6 +172,18 @@ namespace SigilTests
 
             Assert.IsNotNull(d1());
         }
+        
+        [TestMethod]
+        public void Constructor()
+        {
+            var e1 = Emit<Func<RuntimeMethodHandle>>.NewDynamicMethod();
+            e1.LoadConstant(typeof(string).GetConstructor(new []{typeof(char), typeof(int)}));
+            e1.Return();
+
+            var d1 = e1.CreateDelegate();
+
+            Assert.IsNotNull(d1());
+        }
 
         class FieldClass
         {


### PR DESCRIPTION
While working with Sigil I noticed that LoadConstant is missing a overload that takes a ConstructorInfo, I used to do this using the raw ILGenerator and it work.
So I added the overload and all tests, basically they are just copied from the LoadConstant(MethodInfo) overload.

I also noticed that the documentation of OpCodes.Ldtoken [here](https://docs.microsoft.com/de-de/dotnet/api/system.reflection.emit.opcodes.ldtoken?view=netframework-4.7.1) does not mention ConstructorInfo so this might also be outside the specs. 